### PR TITLE
Build with -ffunction-sections -fdata-sections so that we get even smaller elf/binary files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@
 CFLAGS += -g -Wall -Werror -I include
 
 ifeq ($(PLATFORM),cortex-m3)
-  CFLAGS  += -fno-common -Os
   CC      = arm-none-eabi-gcc
   AR      = arm-none-eabi-ar
   CFLAGS += -mcpu=cortex-m3 -mthumb
+  CFLAGS += -fno-common -Os
+  CFLAGS += -ffunction-sections -fdata-sections
 endif
 
 # With this, the makefile should work on Windows also.


### PR DESCRIPTION
Hi, here is a small commit that adds -ffunction-sections and -fdata-sections to CFLAGS so that we get even smaller elf/binary files (if used with --gc-sections at link time).

By the way, I'm really grateful that you have put this library online, with the BSD license. It shrunk my code from 65KiB to 6KiB (going from newlib to baselibc). Thanks!

Best regards,
Bjørn Forsman
