### PR TITLE
Define argument types for malloc_lock_t / malloc_unlock_t.

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -42,8 +42,8 @@ __extern void get_malloc_memory_status(size_t *, size_t *);
  * Until the callbacks are set, malloc doesn't do any locking.
  * malloc_lock() *may* timeout, in which case malloc() will return NULL.
  */
-typedef bool (*malloc_lock_t)();
-typedef void (*malloc_unlock_t)();
+typedef bool (*malloc_lock_t)(void);
+typedef void (*malloc_unlock_t)(void);
 __extern void set_malloc_locking(malloc_lock_t, malloc_unlock_t);
 
 __extern long strtol(const char *, char **, int);

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -23,8 +23,8 @@ static struct free_arena_header __malloc_head = {
 	&__malloc_head
 };
 
-static bool malloc_lock_nop() {return true;}
-static void malloc_unlock_nop() {}
+static bool malloc_lock_nop(void) {return true;}
+static void malloc_unlock_nop(void) {}
 
 static malloc_lock_t malloc_lock = &malloc_lock_nop;
 static malloc_unlock_t malloc_unlock = &malloc_unlock_nop;


### PR DESCRIPTION
The definition was lacking a (void) argument, which caused GCC to emit a warning with -Wstrict-prototypes.

Found while porting the library to RIOT OS (we compile with -Werror by default).

#### Steps to test

Compile with -Wstrict-protototypes with and without this patch.