### PR TITLE
Fix signedness warning in integer printing functions.

### DIFF
--- a/src/tinyprintf.c
+++ b/src/tinyprintf.c
@@ -79,7 +79,7 @@ static void uli2a(unsigned long int num, struct param *p)
     int n = 0;
     unsigned long int d = 1;
     char *bf = p->bf;
-    while (num / d >= p->base)
+    while (num / d >= (unsigned int)p->base)
         d *= p->base;
     while (d != 0) {
         int dgt = num / d;
@@ -108,7 +108,7 @@ static void ui2a(unsigned int num, struct param *p)
     int n = 0;
     unsigned int d = 1;
     char *bf = p->bf;
-    while (num / d >= p->base)
+    while (num / d >= (unsigned int)p->base)
         d *= p->base;
     while (d != 0) {
         int dgt = num / d;
@@ -212,7 +212,7 @@ static unsigned putchw(FILE *putp, struct param *p)
     bf = p->bf;
     while ((ch = *bf++))
         written += putf(putp, ch);
-    
+
     return written;
 }
 
@@ -325,7 +325,7 @@ size_t tfp_format(FILE *putp, const char *fmt, va_list va)
         }
     }
  abort:;
- 
+
  return written;
 }
 


### PR DESCRIPTION
A comparison between signed and unsigned was triggering a warning with GCC's sign-compare option.

Since the base of an integer is always positive, this number can be casted as an unsigned int.

Found while porting this library to RIOT OS.

#### Steps to test

Compile with -Wsign-compare with and without this patch.