### PR TITLE
Fix warning regarding maximum object size.

### DIFF
--- a/src/sprintf.c
+++ b/src/sprintf.c
@@ -3,6 +3,7 @@
  */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <unistd.h>
 
 int sprintf(char *buffer, const char *format, ...)
@@ -11,7 +12,7 @@ int sprintf(char *buffer, const char *format, ...)
 	int rv;
 
 	va_start(ap, format);
-	rv = vsnprintf(buffer, ~(size_t) 0, format, ap);
+	rv = vsnprintf(buffer, PTRDIFF_MAX, format, ap);
 	va_end(ap);
 
 	return rv;

--- a/src/vsprintf.c
+++ b/src/vsprintf.c
@@ -3,9 +3,10 @@
  */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <unistd.h>
 
 int vsprintf(char *buffer, const char *format, va_list ap)
 {
-	return vsnprintf(buffer, ~(size_t) 0, format, ap);
+	return vsnprintf(buffer, PTRDIFF_MAX, format, ap);
 }


### PR DESCRIPTION
The maximum size of an object is not ~(size_t)0 but rather PTRDIFF_MAX. This was triggering GCC's format-truncation warning.

Found while porting this library to RIOT OS.

#### Steps to test

Compile with -Wformat-truncation with and without this patch.