### PR TITLE
Avoid null pointer arithmetic.

### DIFF
--- a/src/bsearch.c
+++ b/src/bsearch.c
@@ -9,14 +9,14 @@ void *bsearch(const void *key, const void *base, size_t nmemb,
 {
 	while (nmemb) {
 		size_t mididx = nmemb / 2;
-		const void *midobj = base + mididx * size;
+		const void *midobj = (const char*)base + mididx * size;
 		int diff = cmp(key, midobj);
 
 		if (diff == 0)
 			return (void *)midobj;
 
 		if (diff > 0) {
-			base = midobj + size;
+			base = (const char*)midobj + size;
 			nmemb -= mididx + 1;
 		} else
 			nmemb = mididx;


### PR DESCRIPTION
Arithmethic on (void*) values is not allowed in standard C. Compiling with -Wpedantic gives a warning about this.

The (void*) values were cast to (char*) as sizeof(char) is guaranteed be 1 (thus preserving the meaning of the `size` parameter).