### PR TITLE
Add a PLATFORM for m68k-elf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,14 @@ else ifeq ($(PLATFORM),cortex-m0)
   CFLAGS += -mcpu=cortex-m0 -mthumb
   CFLAGS += -fno-common -Os
   CFLAGS += -ffunction-sections -fdata-sections
+else ifeq ($(PLATFORM),m68k-elf)
+  CC      = m68k-elf-gcc
+  AR      = m68k-elf-ar
+  CFLAGS += -mcpu=68000
+  CFLAGS += -fno-common -Os
+  CFLAGS += -ffunction-sections -fdata-sections
+  CFLAGS += -ffreestanding
+  CFLAGS += -DNO_UNISTD_H
 endif
 
 # With this, the makefile should work on Windows also.

--- a/src/sprintf.c
+++ b/src/sprintf.c
@@ -4,7 +4,9 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#ifndef NO_UNISTD_H
 #include <unistd.h>
+#endif
 
 int sprintf(char *buffer, const char *format, ...)
 {

--- a/src/vsprintf.c
+++ b/src/vsprintf.c
@@ -4,7 +4,9 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#ifndef NO_UNISTD_H
 #include <unistd.h>
+#endif
 
 int vsprintf(char *buffer, const char *format, va_list ap)
 {


### PR DESCRIPTION
This requires -ffreestanding to build with my cross compiler. Also,
unistd.h is unavailable so the includes in src/*sprintf.c have been
made conditional.